### PR TITLE
Allow plugin to work when git.commit.count can't be determined

### DIFF
--- a/src/main/java/com/lukegb/mojo/build/GitDescribeMojo.java
+++ b/src/main/java/com/lukegb/mojo/build/GitDescribeMojo.java
@@ -175,7 +175,10 @@ public class GitDescribeMojo
     {
         Pattern pattern = Pattern.compile("-(\\d+)-g[0-9a-f]{7}$");
         Matcher matcher = pattern.matcher(describer);
-        matcher.find();
+        if (!matcher.find()) {
+            // git describe didn't find a version number (perhaps there was no tag).
+            return failOutput;
+        }
         String count = matcher.group(1);
         return count;
     }


### PR DESCRIPTION
On error, my original change would cause the plugin to fail.  Very embarassing.
Now, it sets the value of the commit count to the value of the failOutput property ("unknown" by default).
