### PR TITLE
Two new options: --long, and reactor project (multi-module) support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,5 +47,11 @@ The following configuration properties are available:
     outputSuffix
       String to append to git describe/shorttag output.
 
+    long (Default: false)
+      If true, pass the `--long` flag to git-describe.
+
+    setReactorProjectsProperties (Default: false)
+      If true, set the properties on reactor projects.
+
 
 


### PR DESCRIPTION
New option: always git-describe with long format.
New option: enable setting the describe property on reactor projects (multi-module).
