### PR TITLE
Remove the default for outputPrefix

### DIFF
--- a/src/main/java/com/lukegb/mojo/build/GitDescribeMojo.java
+++ b/src/main/java/com/lukegb/mojo/build/GitDescribeMojo.java
@@ -78,7 +78,7 @@ public class GitDescribeMojo
     /**
      * String to prepend to git describe/shorttag output
      *
-     * @parameter default-value="git-"
+     * @parameter
      */
     private String outputPrefix;
 


### PR DESCRIPTION
Since it is impossible to completely remove a default in maven, having a
default where it might be useful to have no value at all is positively
harmful.
